### PR TITLE
update to 3.8.0 beta 2 ?

### DIFF
--- a/unifi-video/Makefile
+++ b/unifi-video/Makefile
@@ -7,7 +7,7 @@ UNIFI_VIDEO_DEB_URL=http://dl.ubnt.com/firmwares/unifi-video/$(VERSION)/unifi-vi
 all: build
 
 build:
-	docker build --no-cache --build-arg UNIFI_VIDEO_VERSION=$(VERSION) --build-arg UNIFI_VIDEO_DEB_URL=$(UNIFI_VIDEO_DEB_URL) -t $(NAME):$(VERSION) --rm .
+	docker build --no-cache --build-arg UNIFI_VIDEO_VERSION=$(VERSION) --build-arg UNIFI_VIDEO_DEB_URL=$(UNIFI_VIDEO_DEB_URL) -t $(NAME):$(VERSION) --rm=true .
 
 test:
 	env NAME=$(NAME) VERSION=$(VERSION) ./mocktest.sh

--- a/unifi-video/Makefile
+++ b/unifi-video/Makefile
@@ -1,5 +1,5 @@
 NAME = ctindel/unifi-video-controller
-VERSION = 3.7.3
+VERSION = 3.8.0
 UNIFI_VIDEO_DEB_URL=http://dl.ubnt.com/firmwares/unifi-video/$(VERSION)/unifi-video_$(VERSION)-Ubuntu14.04_amd64.deb
 
 .PHONY: all build test tag_latest release

--- a/unifi-video/Makefile
+++ b/unifi-video/Makefile
@@ -1,6 +1,6 @@
 NAME = ctindel/unifi-video-controller
 VERSION = 3.8.0
-UNIFI_VIDEO_DEB_URL=http://dl.ubnt.com/firmwares/unifi-video/$(VERSION)/unifi-video_$(VERSION)-Ubuntu14.04_amd64.deb
+UNIFI_VIDEO_DEB_URL=http://dl.ubnt.com/firmwares/ufv/v$(VERSION)/unifi-video.Ubuntu14.04_amd64.v$(VERSION).deb
 
 .PHONY: all build test tag_latest release
 

--- a/unifi-video/Makefile
+++ b/unifi-video/Makefile
@@ -1,5 +1,5 @@
 NAME = ctindel/unifi-video-controller
-VERSION = 3.7.2
+VERSION = 3.7.3
 UNIFI_VIDEO_DEB_URL=http://dl.ubnt.com/firmwares/unifi-video/$(VERSION)/unifi-video_$(VERSION)-Ubuntu14.04_amd64.deb
 
 .PHONY: all build test tag_latest release

--- a/unifi/Makefile
+++ b/unifi/Makefile
@@ -1,5 +1,5 @@
 NAME = ctindel/unifi-controller
-VERSION = 5.5.19
+VERSION = 5.5.20
 UNIFI_DEB_URL=http://dl.ubnt.com/unifi/$(VERSION)/unifi_sysvinit_all.deb
 
 .PHONY: all build test tag_latest release

--- a/unifi/Makefile
+++ b/unifi/Makefile
@@ -7,7 +7,7 @@ UNIFI_DEB_URL=http://dl.ubnt.com/unifi/$(VERSION)/unifi_sysvinit_all.deb
 all: build
 
 build:
-	docker build --no-cache --build-arg UNIFI_VERSION=$(VERSION) --build-arg UNIFI_DEB_URL=$(UNIFI_DEB_URL) -t $(NAME):$(VERSION) --rm .
+	docker build --no-cache --build-arg UNIFI_VERSION=$(VERSION) --build-arg UNIFI_DEB_URL=$(UNIFI_DEB_URL) -t $(NAME):$(VERSION) --rm=true .
 
 test:
 	env NAME=$(NAME) VERSION=$(VERSION) ./mocktest.sh


### PR DESCRIPTION
There is a serious bug in the 3.7.x code that causes recordings to become out of sync and lose valuable events. Any chance you would create a docker version with the new beta code?

New to docker and github so i apologize if this is the wrong place or method of requesting such a thing.

Thanks!